### PR TITLE
Lift hardcoded minimum character length constraint from username autocomplete textfields

### DIFF
--- a/config/params-template.php
+++ b/config/params-template.php
@@ -17,5 +17,24 @@ return [
     'funding-footer'=>'Location funding logo for the footer or leave empty for none',
     'youtube_url' => 'Fill if you have a youtube channel',
     'twitter_url' => 'Fill if you have a twitter account',
-    'copyright' => 'Fill if you want to add a copyright text', 
+    'copyright' => 'Fill if you want to add a copyright text',
+
+
+    /*
+    minimumUsernameLength
+
+    Set this value to the minimum length of a user's username, as per deployment policies
+
+    This value is used to determine the minimum input text length in autocomplete fields where users are being searched
+    based on their username. To avoid missing users whose usernames are smaller than the autocomplete value, this
+    parameter is inspected.
+
+    For example, if a user can have username of user0 but the input text length must be at least 6 characters before
+    the request is made, then no matter what input text is given, user0 will not be retrievable.
+
+    If this value is missing from the parameters, then autocomplete fields will issue requests even for 1-character
+    inputs, which is also a safe default. This however, gets inefficient quickly with the increase of the user-base.
+    Thus, consider defining the minimum username length used throughout the deployment.
+    */
+    'minUsernameLength' => 1
 ];

--- a/config/web.php
+++ b/config/web.php
@@ -2,8 +2,8 @@
 
 $params = require __DIR__ . '/params.php';
 $db = require __DIR__ . '/db.php';
-$aai=(isset($params['aai_auth'])) && ($params['aai_auth']);
-$db2=($aai) ? require __DIR__ . '/db2.php' : ['class' => 'yii\db\Connection'];
+$aai = (isset($params['aai_auth'])) && ($params['aai_auth']);
+$db2 = ($aai) ? require __DIR__ . '/db2.php' : ['class' => 'yii\db\Connection'];
 
 $config = [
     'id' => 'basic',
@@ -11,16 +11,15 @@ $config = [
     'bootstrap' => ['log'],
     'aliases' => [
         '@bower' => '@vendor/bower-asset',
-        '@npm'   => '@vendor/npm-asset',
+        '@npm' => '@vendor/npm-asset',
         '@webvimark' => '@vendor/webvimark/module-user-management/',
     ],
     'components' => [
-        'assetManager'=>[
-            'appendTimestamp'=>true,
+        'assetManager' => [
+            'appendTimestamp' => true,
             'bundles' => [
                 //'yii\bootstrap\BootstrapPluginAsset' => false,
-                'webvimark\extensions\DateRangePicker\DateRangePickerAsset'=>false,
-                
+                'webvimark\extensions\DateRangePicker\DateRangePickerAsset' => false,
             ],
         ],
         'request' => [
@@ -31,14 +30,12 @@ $config = [
             'class' => 'yii\caching\FileCache',
         ],
         'user' => [
-                    'class' => 'webvimark\modules\UserManagement\components\UserConfig',
+            'class' => 'webvimark\modules\UserManagement\components\UserConfig',
 
-                    // Comment this if you don't want to record user logins
-                    // 'on afterLogin' => function($event) {
-                    //     \webvimark\modules\UserManagement\models\UserVisitLog::newVisitor($event->identity->id);
-                    // }
-            // 'identityClass' => 'app\models\User',
-            // 'enableAutoLogin' => true,
+            // Comment this if you don't want to record user logins
+            'on afterLogin' => function ($event) {
+                \webvimark\modules\UserManagement\models\UserVisitLog::newVisitor($event->identity->id);
+            }
         ],
         'errorHandler' => [
             'errorAction' => 'site/error',
@@ -47,7 +44,7 @@ $config = [
             'class' => 'yii\swiftmailer\Mailer',
             'useFileTransport' => false,
             'transport' => [
-            ],  
+            ],
         ],
         'log' => [
             'traceLevel' => YII_DEBUG ? 3 : 0,
@@ -68,7 +65,7 @@ $config = [
             ],
         ],
         */
-        'view'=>(!$aai)? [] :[
+        'view' => (!$aai) ? [] : [
             'theme' => [
                 'pathMap' => [
                     '@webvimark/views/auth' => '@app/views/user/'
@@ -76,11 +73,12 @@ $config = [
             ],
         ],
     ],
-    'modules'=>[
+    'modules' => [
         'user-management' => [
             'class' => 'webvimark\modules\UserManagement\UserManagementModule',
 
-            'enableRegistration' => true,
+            // 'enableRegistration' => true,
+            // 'rolesAfterRegistration' => ['Bronze'],
 
             // Add regexp validation to passwords. Default pattern does not restrict user and can enter any set of characters.
             // The example below allows user to enter :
@@ -92,49 +90,21 @@ $config = [
             // $: anchored to the end of the string
 
             //'passwordRegexp' => '^\S*(?=\S{8,})(?=\S*[a-z])(?=\S*[A-Z])(?=\S*[\d])\S*$',
-        
+
 
             // Here you can set your handler to change layout for any controller or action
             // Tip: you can use this event in any module
-            'on beforeAction'=>function(yii\base\ActionEvent $event) {
-                if ( $event->action->uniqueId == 'user-management/auth/login' )
-                {
-                    $event->action->controller->layout = 'loginLayout.php';
-                };
-            },
+            // 'on beforeAction'=>function(yii\base\ActionEvent $event) {
+            //     if ( $event->action->uniqueId == 'user-management/auth/login' )
+            //     {
+            //         $event->action->controller->layout = 'loginLayout.php';
+            //     };
+            // },
         ],
         // 'ticket' => [
         //     'class' => ricco\ticket\Module::className(),
         // ],
     ],
-    'modules'=>[
-    'user-management' => [
-        'class' => 'webvimark\modules\UserManagement\UserManagementModule',
-
-        // 'enableRegistration' => true,
-
-        // Add regexp validation to passwords. Default pattern does not restrict user and can enter any set of characters.
-        // The example below allows user to enter :
-        // any set of characters
-        // (?=\S{8,}): of at least length 8
-        // (?=\S*[a-z]): containing at least one lowercase letter
-        // (?=\S*[A-Z]): and at least one uppercase letter
-        // (?=\S*[\d]): and at least one number
-        // $: anchored to the end of the string
-
-        //'passwordRegexp' => '^\S*(?=\S{8,})(?=\S*[a-z])(?=\S*[A-Z])(?=\S*[\d])\S*$',
-        
-
-        // Here you can set your handler to change layout for any controller or action
-        // Tip: you can use this event in any module
-        'on beforeAction'=>function(yii\base\ActionEvent $event) {
-                if ( $event->action->uniqueId == 'user-management/auth/login' )
-                {
-                    $event->action->controller->layout = 'loginLayout.php';
-                };
-            },
-    ],
-],
     'params' => $params,
 ];
 

--- a/models/Project.php
+++ b/models/Project.php
@@ -491,7 +491,7 @@ class Project extends \yii\db\ActiveRecord
          * Get active services VMs, machine VMs, volumes and Jupyter servers
          */
         $active_vms=[];
-        $active_machnes=[];
+        $active_machines=[];
         $active_volumes=[];
 
         $vms=Vm::find()->select(['project_id'])->where(['active'=>'t'])->distinct()->all();

--- a/models/User.php
+++ b/models/User.php
@@ -115,11 +115,11 @@ class User extends UserIdentity
         $expansion = strtolower($expansion);
         if($expansion == "left")
         {
-            $search_type = $term;
+            $search_type = "%$term";
         }
         else if($expansion == 'right')
         {
-            $search_type = $term;
+            $search_type = "$term%";
         }
         else
         {
@@ -127,7 +127,7 @@ class User extends UserIdentity
         }
         $rows=$query->select(["levenshtein(username, '$term') as dist","username"])
               ->from('user')
-              ->where(['ilike',"username",$search_type])
+              ->where(['ilike',"username",$search_type, false])
               ->limit($max_num)
               ->orderBy(['dist' => SORT_ASC])
               ->all();

--- a/views/project/edit_cold_storage.php
+++ b/views/project/edit_cold_storage.php
@@ -75,7 +75,7 @@ Headers::begin() ?>
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/edit_cold_storage.php
+++ b/views/project/edit_cold_storage.php
@@ -76,7 +76,7 @@ Headers::begin() ?>
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/edit_machine_compute.php
+++ b/views/project/edit_machine_compute.php
@@ -63,7 +63,7 @@ Headers::begin() ?>
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/edit_machine_compute.php
+++ b/views/project/edit_machine_compute.php
@@ -62,7 +62,7 @@ Headers::begin() ?>
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/edit_ondemand.php
+++ b/views/project/edit_ondemand.php
@@ -93,7 +93,7 @@ Headers::begin() ?>
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/edit_ondemand.php
+++ b/views/project/edit_ondemand.php
@@ -92,7 +92,7 @@ Headers::begin() ?>
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/edit_service.php
+++ b/views/project/edit_service.php
@@ -82,7 +82,7 @@ Headers::begin() ?>
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' =>  Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/edit_service.php
+++ b/views/project/edit_service.php
@@ -81,7 +81,7 @@ Headers::begin() ?>
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' =>  Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/new_cold_storage_request.php
+++ b/views/project/new_cold_storage_request.php
@@ -70,7 +70,7 @@ if (!empty($errors))
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/new_cold_storage_request.php
+++ b/views/project/new_cold_storage_request.php
@@ -69,7 +69,7 @@ if (!empty($errors))
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/new_machine_compute_request.php
+++ b/views/project/new_machine_compute_request.php
@@ -74,7 +74,7 @@ if (!empty($errors))
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/new_machine_compute_request.php
+++ b/views/project/new_machine_compute_request.php
@@ -73,7 +73,7 @@ if (!empty($errors))
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/new_ondemand_request.php
+++ b/views/project/new_ondemand_request.php
@@ -91,7 +91,7 @@ if (!empty($errors))
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 

--- a/views/project/new_ondemand_request.php
+++ b/views/project/new_ondemand_request.php
@@ -92,7 +92,7 @@ if (!empty($errors))
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right',
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/new_service_request.php
+++ b/views/project/new_service_request.php
@@ -93,7 +93,7 @@ if (!empty($errors))
         <br/>
         <?= MagicSearchBox::widget(
             ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
-             'expansion' => 'both', 
+             'expansion' => 'right', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 
              'name'=>'participants', 

--- a/views/project/new_service_request.php
+++ b/views/project/new_service_request.php
@@ -92,7 +92,7 @@ if (!empty($errors))
         <?= Html::label($participating_label, 'user_search_box', ['class'=>'blue-label']) ?>
         <br/>
         <?= MagicSearchBox::widget(
-            ['min_char_to_start' => 3, 
+            ['min_char_to_start' => Yii::$app->params["minUsernameLength"] ?? 1,
              'expansion' => 'both', 
              'suggestions_num' => 5, 
              'html_params' => [ 'id' => 'user_search_box', 


### PR DESCRIPTION
-  Define new deployment param that corresponds to the minimum number of characters a username may have, in any given deployment
- Configure autocomplete textfields that query on usernames, to take into account this parameter, so that all usernames are retrievable
- Modify username search action so that it looks up usernames starting with a given search pattern