### PR TITLE
Implement custom environment overlay ribbon

### DIFF
--- a/components/EnvironmentOverlay.php
+++ b/components/EnvironmentOverlay.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace app\components;
+
+use Yii;
+use yii\base\Widget;
+
+class EnvironmentOverlay extends Widget
+{
+
+    public function run() {
+        $environmentOverlayConfig = Yii::$app->params['environmentOverlay'] ?? [];
+        if (!$environmentOverlayConfig) return '';
+        $environmentType = strtolower($environmentOverlayConfig['environmentType'] ?? 'production');
+        if ($environmentType === 'production') return '';
+
+        $environmentName = $environmentOverlayConfig['environmentName'] ?? $environmentType;
+        $environmentRefUrl = $environmentOverlayConfig['environmentRefUrl'] ?? '';
+
+        return $this->render('environment-overlay', [
+            'environmentType' => $environmentType,
+            'environmentName' => $environmentName,
+            'environmentRefUrl' => $environmentRefUrl
+        ]);
+    }
+}

--- a/components/views/environment-overlay.php
+++ b/components/views/environment-overlay.php
@@ -1,0 +1,40 @@
+<?php
+
+/* @var $environmentType string */
+/* @var $environmentName string */
+/* @var $environmentRefUrl string */
+
+use yii\helpers\Html;
+
+echo Html::cssFile('@web/css/components/environment-overlay.css');
+?>
+
+<?php
+$staticΟverlayClasses = 'environment-overlay';
+$dynamicOverlayClasses = '';
+
+if ($environmentType === 'test') {
+    $dynamicOverlayClasses .= ' environment-overlay-test';
+}
+else if ($environmentType === 'dev') {
+    $dynamicOverlayClasses .= ' environment-overlay-dev';
+}
+
+$overlayClasses = $staticΟverlayClasses . ' ' . $dynamicOverlayClasses;
+?>
+
+<div class="<?= $overlayClasses ?>">
+    <div>
+    <?php
+    if ($environmentRefUrl) {
+    ?>
+        <h4><a target="_blank" href="<?= $environmentRefUrl ?>"><?= $environmentName ?></a></h4>
+    <?php
+    }
+    else {
+    ?>
+        <h3><?= $environmentName ?></h3>
+    <?php
+    }?>
+    </div>
+</div>

--- a/config/params-template.php
+++ b/config/params-template.php
@@ -48,6 +48,21 @@ return [
     'email_verification' => [
         'validity_period' => '1 day', // Value should be a string literal that can be added on a date('c') object
         'email_verification_url' => 'url to the email verification view'
-    ]
+    ],
+
+    /*
+     * Configure environment overlay ribbon: useful for visualizing different deployments to development team
+     * - environmentType: `test` for a test environment, `dev` for a dev environment, `production` or empty for
+     *      production
+     * - environmentName: name of the environment to be displayed on the overlay ribbon. If empty, it will be the
+     *      qualified value of `environmentType`
+     * - environmentRefUrl: optional URL to a page carrying information about the environment (e.g. pull request)
+     */
+    /*
+    'environmentOverlay'=> [
+        'environmentName'=>'string',
+        'environmentType'=>'string',
+        'environmentRefUrl'=>'string[URL]'
+    ]*/
 
 ];

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -13,6 +13,7 @@ use app\components\SupportWindow;
 use webvimark\modules\UserManagement\models\User;
 use app\components\NotificationWidget;
 use app\models\Analytics;
+use app\components\EnvironmentOverlay;
 
 
 AppAsset::register($this);
@@ -55,7 +56,7 @@ if (isset(Yii::$app->params['favicon']) && (!empty(Yii::$app->params['favicon'])
 </head>
 <body>
 <?php $this->beginBody() ?>
-
+<?= EnvironmentOverlay::widget(); ?>
 <div class="wrap">
     <?php
 

--- a/web/css/components/environment-overlay.css
+++ b/web/css/components/environment-overlay.css
@@ -1,0 +1,48 @@
+:root {
+    --overlay-top-offset: 100px;
+    --overlay-thickness: 50px;
+}
+
+.environment-overlay {
+    position: fixed;
+    display: flex;
+    top: var(--overlay-top-offset);
+    left: -1px;
+    z-index: 9999;
+    margin: 1px;
+    border-radius: 2px;
+    padding: 5px;
+    box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.4);
+    width: calc(((var(--overlay-thickness) + var(--overlay-top-offset)) / 0.7071) + 2px) ;
+    height: var(--overlay-thickness);
+    transform-origin: bottom left;
+    transform: rotate(-45deg);
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(138,138,138,0.6);
+}
+
+.environment-overlay>div {
+    max-width: calc((var(--overlay-top-offset) / 0.7071) - 2px);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.environment-overlay>div>h4 {
+    margin: 0;
+}
+
+.environment-overlay a {
+    color: inherit;
+}
+
+.environment-overlay-test {
+    background-color: rgba(135,0,0,0.6);
+    color: white;
+}
+
+.environment-overlay-dev {
+    background-color: rgba(212,186,0,0.6);
+    color: black;
+}


### PR DESCRIPTION
- Implement a ribbon that floats over the page and declares which is the deployed environment
- For production, the ribbon will not be visible
- Ribbon will carry different colors for `dev` and `test` environments
- Ribbon will optionally optionally utilize a reference URL
- Behavior will configurable through application params